### PR TITLE
Explicitly pass when argument to define-obsolete-variable-alias

### DIFF
--- a/hyperspec.el
+++ b/hyperspec.el
@@ -1316,7 +1316,7 @@ If you copy the HyperSpec to another location, customize the variable
   "Function that creates a URL for a glossary term.")
 
 (define-obsolete-variable-alias 'common-lisp-glossary-fun
-  'common-lisp-hyperspec-glossary-function)
+  'common-lisp-hyperspec-glossary-function nil)
 
 (defvar common-lisp-hyperspec--glossary-terms (make-hash-table :test #'equal)
   "Collection of glossary terms and relative URLs.")


### PR DESCRIPTION
This is necessary due to recent changes (and apparently long-time
deprecation):
https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=32c6732d16385f242b1109517f25e9aefd6caa5c